### PR TITLE
Add quick click and drag builder option

### DIFF
--- a/src/components/builder/builderMode.ts
+++ b/src/components/builder/builderMode.ts
@@ -10,20 +10,51 @@ export class BuilderMode {
 
     static handleMouseMove(evt: MouseEvent) {
         // TODO: add movement with a click and drag
-        this.handleMouseClick(evt, State.builderState.isClicked);
+        if(!State.builderState.dragging) {
+            this.handleMouseClick(evt, State.builderState.isClicked);
+        }
     }
 
     static handleMouseClick(evt: MouseEvent, isClicked: boolean) {
+        if(State.builderState.handleMouseClick && State.builderState.shiftClicked && !State.builderState.isClicked && isClicked) {
+            State.builderState.isClicked = isClicked;
+            State.builderState.dragging = true;
+
+            State.builderState.clickedPosition = RenderingUtilities.toGameCoordinates({ x: evt.clientX, y: evt.clientY });
+            State.builderState.clickedGridCoords = RenderingUtilities.toGameCoordsImgRoot(State.builderState.clickedPosition);
+            return;
+        } else if(State.builderState.handleMouseClick && State.builderState.dragging && State.builderState.isClicked && !isClicked) {
+            State.builderState.isClicked = isClicked;
+            State.builderState.shiftClicked = false;
+            State.builderState.dragging = false;
+
+            const endPoint = RenderingUtilities.toGameCoordinates({ x: evt.clientX, y: evt.clientY });
+            const endGameCoords = RenderingUtilities.toGameCoordsImgRoot(endPoint);
+
+            if(State.builderState.removingTiles || evt.button === 2) {
+                this.removeTilesToStage(State.builderState.clickedGridCoords, endGameCoords);
+            } else {
+                this.addTilesToStage(State.builderState.clickedGridCoords, endGameCoords);
+            }
+            return;
+        }
+
         State.builderState.isClicked = isClicked;
         if (State.builderState.handleMouseClick && isClicked) {
             State.builderState.clickedPosition = RenderingUtilities.toGameCoordinates({ x: evt.clientX, y: evt.clientY });
             State.builderState.clickedGridCoords = RenderingUtilities.toGameCoordsImgRoot(State.builderState.clickedPosition);
             this.checkRegion(State.builderState.clickedGridCoords);
-            if (State.builderState.removingTiles) {
-                this.deleteTileFromStage();
+            if (State.builderState.removingTiles || evt.button === 2) {
+                this.deleteTileFromStage(State.builderState.clickedGridCoords);
             } else {
-                this.addTileToStage();
+                this.addTileToStage(State.builderState.clickedGridCoords);
             }
+        }
+    }
+
+    static handleKeyPress(key: string, pressed: boolean) {
+        if('Shift' === key) {
+            State.builderState.shiftClicked = pressed;
         }
     }
 
@@ -44,6 +75,10 @@ export class BuilderMode {
         RenderingUtilities.zoomDimensionsInOrOut(18);
         BuilderMenu.addBuilderMenu();
         TileBuilder.openTileSelector();
+
+        State.builderState.keyListener = (evt: KeyboardEvent) => this.handleKeyPress(evt.key, true);
+        document.addEventListener('keydown', State.builderState.keyListener);
+        document.addEventListener('keyup', State.builderState.keyListener);
 
         State.gameState.canvas.canvasElement.addEventListener('mousemove', (evt: MouseEvent) => this.handleMouseMove(evt));
         State.gameState.canvas.canvasElement.addEventListener('mousedown', (evt: MouseEvent) => this.handleMouseClick(evt, true));
@@ -72,6 +107,10 @@ export class BuilderMode {
             State.builderState.builderMode = false;
             State.builderState.handleMouseClick = false;
             State.builderState.builderEngine.stop();
+
+            document.removeEventListener('keydown', State.builderState.keyListener);
+            document.removeEventListener('keyup', State.builderState.keyListener);
+
             State.gameState.canvas.canvasElement.removeEventListener('mousemove', () => console.log('Removing mousemove evt listener'));
             State.gameState.canvas.canvasElement.removeEventListener('mousedown', () => console.log('Removing mousedown evt listener'));
             State.gameState.canvas.canvasElement.removeEventListener('mouseup', () => console.log('Removing mouseup evt listener'));
@@ -90,23 +129,36 @@ export class BuilderMode {
         return tileId.split('-')[1];
     }
 
-    static addTileToStage() {
-        const col = State.builderState.clickedGridCoords.x;
-        const row = State.builderState.clickedGridCoords.y;
-        const lookUpValue = this.getSelectedTileLookUpValue();
-
-        const gridId = RenderingUtilities.stringifyColAndRow(col, row);
-        const stageTile = new StageTile(row, col, lookUpValue);
-        State.stageState.tiles.set(gridId, stageTile);
+    static addTilesToStage(pointA: Point, pointB: Point) {
+        this.updateTilesToStage(pointA, pointB, this.getSelectedTileLookUpValue());
     }
 
-    static deleteTileFromStage() {
-        const col = State.builderState.clickedGridCoords.x;
-        const row = State.builderState.clickedGridCoords.y;
-        const lookUpValue = '00';
+    static removeTilesToStage(pointA: Point, pointB: Point) {
+        this.updateTilesToStage(pointA, pointB, '00');
+    }
+
+    static updateTilesToStage(pointA: Point, pointB: Point, tileValue: string) {
+        for(let col = Math.min(pointA.x, pointB.x); col < Math.max(pointA.x, pointB.x); col++) {
+            for(let row = Math.min(pointA.y, pointB.y); row < Math.max(pointA.y, pointB.y); row++) {
+                this.updateTile({x: col, y: row}, tileValue);
+            }
+        }
+    }
+
+    static addTileToStage(point: Point) {
+        this.updateTile(point, this.getSelectedTileLookUpValue());
+    }
+
+    static deleteTileFromStage(point: Point) {
+        this.updateTile(point, '00');
+    }
+
+    static updateTile(point: Point, tileValue: string) {
+        const col = point.x;
+        const row = point.y;
 
         const gridId = RenderingUtilities.stringifyColAndRow(col, row);
-        const stageTile = new StageTile(row, col, lookUpValue);
+        const stageTile = new StageTile(row, col, tileValue);
         State.stageState.tiles.set(gridId, stageTile);
     }
 

--- a/src/states/builderState.ts
+++ b/src/states/builderState.ts
@@ -1,4 +1,3 @@
-import { MenuOptions } from '../constants/menuOptions';
 import { BuilderModeEngine } from '../engines/builderModeEngine';
 import { Point } from '../interfaces/point';
 
@@ -8,6 +7,8 @@ export class BuilderState {
     builderEngine: BuilderModeEngine;
     handleMouseClick: boolean;
     isClicked: boolean;
+    shiftClicked: boolean;
+    dragging: boolean;
     clickedPosition: Point;
     clickedGridCoords: Point;
     saving: boolean;
@@ -28,14 +29,17 @@ export class BuilderState {
     setStartScreen: any;
     showGrid: boolean;
     showRegions: boolean;
+    keyListener: (evt: KeyboardEvent) => void;
 
     constructor() {
         this.builderMode = false;
         this.builderEngine = new BuilderModeEngine();
         this.builderMenuOpen = false;
+        this.dragging = false;
         this.tileSelectorOpen = false;
         this.handleMouseClick = false;
         this.removingTiles = false;
+        this.shiftClicked = false;
         this.showGrid = false;
         this.showRegions = false;
         this.wheelSpeedReducer = 6;


### PR DESCRIPTION
## Changes

- added a option on builder to hold the shift key while building to fill in or remove large chunks with a selected tile
- hold shift, click starting corner, drag to desired location, and release mouse click
- left click to fill in with selected tile
- right click to remove tiles

## Screenshots

![image](https://user-images.githubusercontent.com/47049368/108017017-7b2c0180-6fd9-11eb-9d49-dc0892e06a3a.png)
